### PR TITLE
Expose failure adapters through topic failure configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ dist: trusty
 sudo: required
 node_js:
   - '8'
-branches:
-  only:
-    - master
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 env:
   - DOCKER_COMPOSE_VERSION=1.16.1
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ dist: trusty
 sudo: required
 node_js:
   - '8'
+branches:	
+  only:	
+    - master	
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 env:
   - DOCKER_COMPOSE_VERSION=1.16.1
 before_install:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ const client = new Kafka({ ... })
 const dlq = new DLQ({ client })
 
 const topic = 'example-topic'
+const failureAdapter = new failureAdapters.Kafka({ client, topic: `${topic}.dead-letter-queue` })
 
 const { eachMessage } = dlq.consumer({
   topics: {
-    [topic]: {
-      failureAdapter: failureAdapters.kafka({ topic: `${topic}.dead-letter-queue` })
-    }
+    [topic]: { failureAdapter }
   },
   eachMessage: async ({ topic, partition, message }) => {
     throw new Error('Failed to process message')

--- a/README.md
+++ b/README.md
@@ -19,32 +19,20 @@ queue.
 
 ```javascript
 const { Kafka } = require('kafkajs')
-const DLQ = require('kafkajs-dlq')
+const { DLQ, failureAdapters } = require('kafkajs-dlq')
 
 const client = new Kafka({ ... })
 const dlq = new DLQ({ client })
 
 const topic = 'example-topic'
 
-const { eachMessage, disconnect } = dlq.consumer({
+const { eachMessage } = dlq.consumer({
   topics: {
     [topic]: {
-      delayedExecution: [
-        { topic: `${topic}.5m`, delay: 5 * 60 * 1000 },
-        { topic: `${topic}.20m`, delay: 20 * 60 * 1000 }
-      ],
-      onFailure: dlq.kafkaFailureAdapter({ topic: `${topic}.dead-letter-queue` })
+      failureAdapter: failureAdapters.kafka({ topic: `${topic}.dead-letter-queue` })
     }
   },
   eachMessage: async ({ topic, partition, message }) => {
-    // If eachMessage rejects, the message will be
-    // produced to the first delayed execution topic
-    // and re-consumed after the delay.
-    //
-    // Once it has failed to be processed in each of
-    // the delayed execution topics, it gets passed
-    // to the failure adapter. In this case, it will
-    // be published to the indicated topic.
     throw new Error('Failed to process message')
   }
 })
@@ -58,8 +46,4 @@ const run = async () => {
 }
 
 run()
-
-// Remember to call "disconnect" whenever you disconnect
-// your Kafka client
-await disconnect()
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ const { eachMessage } = Dlq.consumer({
     [topic]: 'example-dead-letter-queue'
   },
   producer,
-  consumer,
   eachMessage: async ({ topic, partition, message }) => {
     // If eachMessage rejects, the message will be
     // produced on the dead-letter queue

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-const { consumer } = require("./src");
+const DLQ = require("./src");
+const FailureAdapters = require("./src/failureAdapters");
 
 module.exports = {
-  consumer
+  DLQ,
+  FailureAdapters
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const DLQ = require("./src");
-const FailureAdapters = require("./src/failureAdapters");
+const failureAdapters = require("./src/failureAdapters");
 
 module.exports = {
   DLQ,
-  FailureAdapters
+  failureAdapters
 };

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "husky": "^0.14.3",
     "ip": "^1.1.5",
     "jest": "^23.4.2",
-    "kafkajs": "^1.2.0",
+    "kafkajs": "^1.3.0",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.7",
     "prettier-check": "^2.0.0"
   },
   "scripts": {
-    "test": "NODE_ENV=test yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh './node_modules/.bin/jest --maxWorkers=4 --no-watchman --forceExit --detectOpenHandles'",
+    "test": "NODE_ENV=test yarn lint && ./scripts/testWithKafka.sh './node_modules/.bin/jest --maxWorkers=4 --no-watchman --forceExit --detectOpenHandles'",
     "test:watch": "DO_NOT_STOP=1 yarn test -- --watch",
     "format": "find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -0 prettier --write",
     "lint": "find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -0 prettier-check",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "husky": "^0.14.3",
     "ip": "^1.1.5",
     "jest": "^23.4.2",
-    "kafkajs": "^1.3.0",
+    "kafkajs": "https://github.com/tulios/kafkajs.git#0f04b0b080e5aaf065eca433c62a5f9c0a3efe66",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.7",
     "prettier-check": "^2.0.0"

--- a/scripts/testWithKafka.sh
+++ b/scripts/testWithKafka.sh
@@ -39,6 +39,6 @@ TEST_EXIT=$?
 echo
 
 if [ -z ${DO_NOT_STOP} ]; then
-  docker-compose down --remove-orphans
+  docker-compose -p kafkajsdlq down --remove-orphans
 fi
 exit ${TEST_EXIT}

--- a/scripts/waitForKafka.js
+++ b/scripts/waitForKafka.js
@@ -61,7 +61,7 @@ waitForNode(kafkaContainerId);
 console.log("\nAll nodes up:");
 console.log(
   execa
-    .shellSync(`HOST_IP=${process.env.HOST_IP} docker-compose ps`)
+    .shellSync(`HOST_IP=${process.env.HOST_IP} docker-compose -p kafkajsdlq ps`)
     .stdout.toString("utf-8")
 );
 

--- a/src/consumer.integration.spec.js
+++ b/src/consumer.integration.spec.js
@@ -1,5 +1,5 @@
 const { Kafka, logLevel } = require("kafkajs");
-const { DLQ, FailureAdapters } = require("../");
+const { DLQ, failureAdapters } = require("../");
 
 const {
   secureRandom,
@@ -55,7 +55,7 @@ describe("[Integration] Consumer", () => {
     await sourceConsumer.subscribe({ topic: sourceTopic, fromBeginning: true });
     await dlqConsumer.subscribe({ topic: dlqTopic, fromBeginning: true });
 
-    const failureAdapter = new FailureAdapters.KafkaFailureAdapter({
+    const sendToKafka = new failureAdapters.Kafka({
       topic: dlqTopic,
       client
     });
@@ -64,7 +64,11 @@ describe("[Integration] Consumer", () => {
 
     let sourceMessagesConsumed = [];
     const { eachMessage } = dlq.consumer({
-      failureAdapter,
+      topics: {
+        [sourceTopic]: {
+          failureAdapter: sendToKafka
+        }
+      },
       client,
       eachMessage: async event => {
         sourceMessagesConsumed.push(event);

--- a/src/consumer.integration.spec.js
+++ b/src/consumer.integration.spec.js
@@ -23,7 +23,7 @@ describe("[Integration] Consumer", () => {
       logLevel: logLevel.NOTHING,
       retry: {
         initialRetryTime: 100,
-        retries: 1
+        retries: 2
       }
     });
     sourceConsumer = client.consumer({

--- a/src/consumer.integration.spec.js
+++ b/src/consumer.integration.spec.js
@@ -1,5 +1,5 @@
 const { Kafka, logLevel } = require("kafkajs");
-const Dlq = require("kafkajs-dlq");
+const { DLQ, FailureAdapters } = require("../");
 
 const {
   secureRandom,
@@ -55,11 +55,17 @@ describe("[Integration] Consumer", () => {
     await sourceConsumer.subscribe({ topic: sourceTopic, fromBeginning: true });
     await dlqConsumer.subscribe({ topic: dlqTopic, fromBeginning: true });
 
+    const failureAdapter = new FailureAdapters.KafkaFailureAdapter({
+      topic: dlqTopic,
+      client
+    });
+
+    const dlq = new DLQ({ client });
+
     let sourceMessagesConsumed = [];
-    const { eachMessage } = Dlq.consumer({
-      topics: { [sourceTopic]: dlqTopic },
-      consumer: sourceConsumer,
-      producer,
+    const { eachMessage } = dlq.consumer({
+      failureAdapter,
+      client,
       eachMessage: async event => {
         sourceMessagesConsumed.push(event);
 
@@ -92,74 +98,5 @@ describe("[Integration] Consumer", () => {
     expect(messagesConsumed.map(toComparable)).toEqual(
       sourceMessagesConsumed.filter((_, i) => i % 2 !== 0).map(toComparable)
     );
-  });
-
-  it("seeks to the current offset if it fails to produce to the dead letter queue", async () => {
-    await sourceConsumer.subscribe({ topic: sourceTopic, fromBeginning: true });
-    await dlqConsumer.subscribe({ topic: dlqTopic, fromBeginning: true });
-
-    let firstProduceCall = true;
-    let sourceMessagesConsumed = [];
-    const { eachMessage } = Dlq.consumer({
-      topics: { [sourceTopic]: dlqTopic },
-      consumer: sourceConsumer,
-      producer: {
-        send: async (...args) => {
-          if (firstProduceCall) {
-            firstProduceCall = false;
-            throw new Error("Failed to produce");
-          }
-
-          await producer.send(...args);
-        }
-      },
-      eachMessage: async event => {
-        sourceMessagesConsumed.push(event);
-
-        if (sourceMessagesConsumed.length < 3) {
-          throw new Error("Failed to process message");
-        }
-      }
-    });
-
-    const messagesConsumed = [];
-    dlqConsumer.run({
-      eachMessage: async event => messagesConsumed.push(event)
-    });
-
-    sourceConsumer.run({ eachMessage });
-
-    const messages = [
-      { key: `key-${secureRandom()}`, value: `key-${secureRandom()}` },
-      { key: `key-${secureRandom()}`, value: `key-${secureRandom()}` },
-      { key: `key-${secureRandom()}`, value: `key-${secureRandom()}` },
-      { key: `key-${secureRandom()}`, value: `key-${secureRandom()}` }
-    ];
-
-    for (let message of messages) {
-      await producer.send({
-        topic: sourceTopic,
-        messages: [message]
-      });
-    }
-
-    await waitForMessages(messagesConsumed, { number: 1 });
-    await waitForMessages(sourceMessagesConsumed, { number: 3 });
-
-    /**
-     * @TODO: KafkaJS does not abort the current batch when
-     * calling `seek` within `eachMessage`, which means that
-     * if the batch contains 4 messages, the first one is rejected
-     * and we fail to send it to the DLQ, we will still process
-     * the remaining 3 messages before seeking back to the first,
-     * which means that the 3 will be processed twice.
-     *
-     * expect(
-     *   messagesConsumed.map(toComparable).map(({ key, value }) => ({
-     *     key: key.toString(),
-     *     value: value.toString()
-     *   }))
-     * ).toEqual([messages[0]]);
-     */
   });
 });

--- a/src/consumer.integration.spec.js
+++ b/src/consumer.integration.spec.js
@@ -64,6 +64,7 @@ describe("[Integration] Consumer", () => {
 
     let sourceMessagesConsumed = [];
     const { eachMessage } = dlq.consumer({
+      consumer: sourceConsumer,
       topics: {
         [sourceTopic]: {
           failureAdapter: sendToKafka

--- a/src/consumer/consumer.spec.js
+++ b/src/consumer/consumer.spec.js
@@ -1,5 +1,5 @@
 const { consumer } = require("../../");
-const { KafkaJSDLQNotImplemented } = require("../errors");
+const { KafkaJSDLQNotImplemented, KafkaJSDLQAbortBatch } = require("../errors");
 
 describe("Consumer", () => {
   let sendMock, seekMock;
@@ -121,7 +121,7 @@ describe("Consumer", () => {
         });
       });
 
-      it("seeks back to the message offset when sending to the dead-letter queue fails", async () => {
+      it("throws a KafkaJSDLQAbortBatch error when sending to the dead-letter queue fails", async () => {
         const args = {
           topic: "source",
           partition: 0,
@@ -138,13 +138,9 @@ describe("Consumer", () => {
           throw new Error("Failed to send to dead-letter queue");
         });
 
-        await eachMessage(args);
-
-        expect(kafkaConsumer.seek).toHaveBeenCalledWith({
-          topic: args.topic,
-          partition: args.partition,
-          offset: args.message.offset
-        });
+        await expect(eachMessage(args)).rejects.toThrowError(
+          KafkaJSDLQAbortBatch
+        );
       });
     });
   });

--- a/src/consumer/messageHandler.js
+++ b/src/consumer/messageHandler.js
@@ -1,5 +1,13 @@
 const { KafkaJSDLQAbortBatch } = require("../errors");
-const { KafkaFailureAdapter } = require("../failureAdapters");
+const { _initialized } = require("../failureAdapters/adapter");
+
+const setupIfNeeded = async adapter => {
+  if (!adapter[_initialized]) {
+    await adapter.setup();
+
+    adapter[_initialized] = true;
+  }
+};
 
 module.exports = ({ eachMessage, topics, logger }) => {
   return async (...args) => {
@@ -14,6 +22,10 @@ module.exports = ({ eachMessage, topics, logger }) => {
       }
 
       try {
+        // Set up in case consumer was already connected
+        // before DLQ consumer was initialized
+        await setupIfNeeded(topicConfiguration.failureAdapter);
+
         await topicConfiguration.failureAdapter.onFailure({
           topic,
           partition,

--- a/src/errors.js
+++ b/src/errors.js
@@ -9,9 +9,11 @@ class KafkaJSDLQError extends Error {
 
 class KafkaJSDLQNotImplemented extends KafkaJSDLQError {}
 class KafkaJSDLQTimeout extends KafkaJSDLQError {}
+class KafkaJSDLQAbortBatch extends KafkaJSDLQError {}
 
 module.exports = {
   KafkaJSDLQError,
   KafkaJSDLQNotImplemented,
-  KafkaJSDLQTimeout
+  KafkaJSDLQTimeout,
+  KafkaJSDLQAbortBatch
 };

--- a/src/failureAdapters/adapter.js
+++ b/src/failureAdapters/adapter.js
@@ -1,0 +1,30 @@
+/**
+ * FailureAdapters are expected to implement the async
+ * method "onFailure". In case the failure handling fails,
+ * they are expected to throw an error.
+ */
+module.exports = class FailureAdapter {
+  constructor() {
+    if (this.constructor === FailureAdapter) {
+      throw new TypeError(
+        `Can not construct abstract class ${FailureAdapter.name}.`
+      );
+    }
+
+    if (this.onFailure === FailureAdapter.prototype.onFailure) {
+      throw new TypeError(
+        `Abstract method ${this.onFailure.name} not implemented by ${
+          this.constructor.name
+        }.`
+      );
+    }
+  }
+
+  async onFailure({ topic, partition, message }) {
+    throw new TypeError(
+      `Calling abstract method ${this.onFailure.name} of ${
+        FailureAdapter.name
+      }.`
+    );
+  }
+};

--- a/src/failureAdapters/adapter.js
+++ b/src/failureAdapters/adapter.js
@@ -1,9 +1,11 @@
+const _initialized = Symbol();
+
 /**
  * FailureAdapters are expected to implement the async
  * method "onFailure". In case the failure handling fails,
  * they are expected to throw an error.
  */
-module.exports = class FailureAdapter {
+class FailureAdapter {
   constructor() {
     if (this.constructor === FailureAdapter) {
       throw new TypeError(
@@ -20,6 +22,10 @@ module.exports = class FailureAdapter {
     }
   }
 
+  async setup() {}
+
+  async teardown() {}
+
   async onFailure({ topic, partition, message }) {
     throw new TypeError(
       `Calling abstract method ${this.onFailure.name} of ${
@@ -27,4 +33,9 @@ module.exports = class FailureAdapter {
       }.`
     );
   }
+}
+
+module.exports = {
+  FailureAdapter,
+  _initialized
 };

--- a/src/failureAdapters/adapter.spec.js
+++ b/src/failureAdapters/adapter.spec.js
@@ -1,4 +1,4 @@
-const Adapter = require("./adapter");
+const { FailureAdapter: Adapter } = require("./adapter");
 
 describe("Failure Adapter", () => {
   it("should throw when instantiated", () => {

--- a/src/failureAdapters/adapter.spec.js
+++ b/src/failureAdapters/adapter.spec.js
@@ -1,0 +1,17 @@
+const Adapter = require("./adapter");
+
+describe("Failure Adapter", () => {
+  it("should throw when instantiated", () => {
+    expect(() => new Adapter()).toThrowError(
+      "Can not construct abstract class FailureAdapter."
+    );
+  });
+
+  it('should throw if child class does not implement "onFailure"', () => {
+    class Foo extends Adapter {}
+
+    expect(() => new Foo()).toThrowError(
+      "Abstract method onFailure not implemented by Foo."
+    );
+  });
+});

--- a/src/failureAdapters/index.js
+++ b/src/failureAdapters/index.js
@@ -1,0 +1,7 @@
+const FailureAdapter = require("./adapter");
+const KafkaFailureAdapter = require("./kafka");
+
+module.exports = {
+  FailureAdapter,
+  KafkaFailureAdapter
+};

--- a/src/failureAdapters/index.js
+++ b/src/failureAdapters/index.js
@@ -1,7 +1,7 @@
 const FailureAdapter = require("./adapter");
-const KafkaFailureAdapter = require("./kafka");
+const Kafka = require("./kafka");
 
 module.exports = {
   FailureAdapter,
-  KafkaFailureAdapter
+  Kafka
 };

--- a/src/failureAdapters/index.js
+++ b/src/failureAdapters/index.js
@@ -1,4 +1,4 @@
-const FailureAdapter = require("./adapter");
+const { FailureAdapter } = require("./adapter");
 const Kafka = require("./kafka");
 
 module.exports = {

--- a/src/failureAdapters/kafka.js
+++ b/src/failureAdapters/kafka.js
@@ -1,4 +1,4 @@
-const FailureAdapter = require("./adapter");
+const { FailureAdapter } = require("./adapter");
 
 module.exports = class KafkaFailureAdapter extends FailureAdapter {
   constructor({ client, topic }) {
@@ -9,16 +9,18 @@ module.exports = class KafkaFailureAdapter extends FailureAdapter {
     this.topic = topic;
   }
 
-  async onFailure({ message }) {
-    // @TODO: Remove once KafkaJS exposes connect/disconnect events
+  async setup() {
     await this.producer.connect();
+  }
 
+  async teardown() {
+    await this.producer.disconnect();
+  }
+
+  async onFailure({ message }) {
     await this.producer.send({
       topic: this.topic,
       messages: [message]
     });
-
-    // @TODO: Remove once KafkaJS exposes connect/disconnect events
-    await this.producer.disconnect();
   }
 };

--- a/src/failureAdapters/kafka.js
+++ b/src/failureAdapters/kafka.js
@@ -1,0 +1,22 @@
+const FailureAdapter = require("./adapter");
+
+module.exports = class KafkaFailureAdapter extends FailureAdapter {
+  constructor({ client, topic }) {
+    super();
+
+    this.client = client;
+    this.producer = client.producer();
+    this.topic = topic;
+  }
+
+  async onFailure({ message }) {
+    this.producer.logger().info("Received message in failure handler", {
+      message,
+      topic: this.topic
+    });
+    await this.producer.send({
+      topic: this.topic,
+      messages: [message]
+    });
+  }
+};

--- a/src/failureAdapters/kafka.js
+++ b/src/failureAdapters/kafka.js
@@ -10,13 +10,15 @@ module.exports = class KafkaFailureAdapter extends FailureAdapter {
   }
 
   async onFailure({ message }) {
-    this.producer.logger().info("Received message in failure handler", {
-      message,
-      topic: this.topic
-    });
+    // @TODO: Remove once KafkaJS exposes connect/disconnect events
+    await this.producer.connect();
+
     await this.producer.send({
       topic: this.topic,
       messages: [message]
     });
+
+    // @TODO: Remove once KafkaJS exposes connect/disconnect events
+    await this.producer.disconnect();
   }
 };

--- a/src/failureAdapters/kafka.spec.js
+++ b/src/failureAdapters/kafka.spec.js
@@ -1,0 +1,43 @@
+const KafkaFailureAdapter = require("./kafka");
+const { KafkaJSDLQAbortBatch } = require("../errors");
+
+let logger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+};
+
+logger.namespace = () => logger;
+
+let producer = {
+  logger: () => logger,
+  send: jest.fn()
+};
+
+const client = {
+  producer: () => producer,
+  logger: () => logger
+};
+
+const topic = "failure-topic";
+const message = { key: "key", value: "value" };
+
+describe("Kafka Failure Adapter", () => {
+  it("produces the message to the specified topic when invoked", async () => {
+    producer.send.mockImplementation(() => Promise.resolve());
+    const adapter = new KafkaFailureAdapter({ client, topic });
+
+    await adapter.onFailure({ message });
+
+    expect(producer.send).toHaveBeenCalledWith({ topic, messages: [message] });
+  });
+
+  it("throws an error when failing to produce to the topic", async () => {
+    const error = new Error("Something went wrong");
+    producer.send.mockImplementation(() => Promise.reject(error));
+
+    const adapter = new KafkaFailureAdapter({ client, topic });
+
+    await expect(adapter.onFailure({ message })).rejects.toThrowError(error);
+  });
+});

--- a/src/failureAdapters/kafka.spec.js
+++ b/src/failureAdapters/kafka.spec.js
@@ -9,7 +9,9 @@ logger.namespace = () => logger;
 
 let producer = {
   logger: () => logger,
-  send: jest.fn()
+  send: jest.fn(),
+  connect: jest.fn(),
+  disconnect: jest.fn()
 };
 
 const client = {

--- a/src/failureAdapters/kafka.spec.js
+++ b/src/failureAdapters/kafka.spec.js
@@ -23,6 +23,22 @@ const topic = "failure-topic";
 const message = { key: "key", value: "value" };
 
 describe("Kafka Failure Adapter", () => {
+  it("connects the producer when initialized", async () => {
+    const adapter = new KafkaFailureAdapter({ client, topic });
+
+    await adapter.setup();
+
+    expect(producer.connect).toHaveBeenCalled();
+  });
+
+  it("disconnects the producer on teardown", async () => {
+    const adapter = new KafkaFailureAdapter({ client, topic });
+
+    await adapter.teardown();
+
+    expect(producer.disconnect).toHaveBeenCalled();
+  });
+
   it("produces the message to the specified topic when invoked", async () => {
     producer.send.mockImplementation(() => Promise.resolve());
     const adapter = new KafkaFailureAdapter({ client, topic });

--- a/src/failureAdapters/kafka.spec.js
+++ b/src/failureAdapters/kafka.spec.js
@@ -1,6 +1,4 @@
-const KafkaFailureAdapter = require("./kafka");
-const { KafkaJSDLQAbortBatch } = require("../errors");
-
+const { Kafka: KafkaFailureAdapter } = require(".");
 let logger = {
   info: jest.fn(),
   warn: jest.fn(),

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,9 @@ module.exports = class DLQ {
     this.client = client;
   }
 
-  consumer({ topics, eachMessage, eachBatch } = {}) {
+  consumer({ consumer: kafkaJsConsumer, topics, eachMessage, eachBatch } = {}) {
     const consumer = new Consumer({
+      consumer: kafkaJsConsumer,
       client: this.client,
       topics,
       eachMessage,

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,10 @@ module.exports = class DLQ {
     this.client = client;
   }
 
-  consumer({ failureAdapter, eachMessage, eachBatch } = {}) {
+  consumer({ topics, eachMessage, eachBatch } = {}) {
     const consumer = new Consumer({
       client: this.client,
-      failureAdapter,
+      topics,
       eachMessage,
       eachBatch
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,23 @@
-const createConsumer = require("./consumer");
+const Consumer = require("./consumer");
+const { KafkaJSDLQError } = require("./errors");
 
-module.exports = {
-  consumer: createConsumer
+module.exports = class DLQ {
+  constructor({ client }) {
+    if (!client) {
+      throw new KafkaJSDLQError('"client" must be an instance of KafkaJS');
+    }
+
+    this.client = client;
+  }
+
+  consumer({ failureAdapter, eachMessage, eachBatch } = {}) {
+    const consumer = new Consumer({
+      client: this.client,
+      failureAdapter,
+      eachMessage,
+      eachBatch
+    });
+
+    return consumer.handlers();
+  }
 };

--- a/testHelpers/setup.js
+++ b/testHelpers/setup.js
@@ -1,1 +1,1 @@
-jest.setTimeout(25000);
+jest.setTimeout(45000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,14 +3,14 @@
 
 
 "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz#0024f96fdf7028a21d68e273afd4e953214a1ead"
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-rc.0.tgz#6732d13c3e303d1dd2e45a23a8cf7c8196062c86"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.54"
+    "@babel/highlight" "7.0.0-rc.0"
 
-"@babel/highlight@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.54.tgz#155d507358329b8e7068970017c3fd74a9b08584"
+"@babel/highlight@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-rc.0.tgz#3f356ec31768ba1b03c74dc4437ca047bb56a845"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -164,8 +164,10 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  dependencies:
+    safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -206,8 +208,8 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
 aws4@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -423,8 +425,8 @@ bser@^2.0.0:
     node-int64 "^0.4.0"
 
 buffer-from@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -573,8 +575,8 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 commander@^2.14.1, commander@^2.9.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 compare-versions@^3.1.0:
   version "3.3.0"
@@ -609,8 +611,8 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
 cosmiconfig@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
@@ -749,10 +751,11 @@ domexception@^1.0.1:
     webidl-conversions "^4.0.2"
 
 ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
   dependencies:
     jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -1972,9 +1975,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kafkajs@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.2.0.tgz#eef056c9be157710c725a3755302c14d8e4607a7"
+kafkajs@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.3.0.tgz#1ab046238a578bd13dc1623d057b57b5ae8d4cd4"
   dependencies:
     long "^4.0.0"
 
@@ -2326,8 +2329,8 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 needle@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.2.tgz#1120ca4c41f2fcc6976fd28a8968afe239929418"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -2432,8 +2435,8 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 nwsapi@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.7.tgz#6fc54c254621f10cac5225b76e81c74120139b78"
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
 oauth-sign@~0.8.2:
   version "0.8.2"
@@ -2618,8 +2621,8 @@ path-key@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -2686,8 +2689,8 @@ prettier-check@^2.0.0:
     execa "^0.6.0"
 
 prettier@^1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 pretty-format@^23.2.0:
   version "23.2.0"
@@ -2705,8 +2708,8 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 prompts@^0.1.9:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.13.tgz#7fad7ee1c6cafe49834ca0b2a6a471262de57620"
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
   dependencies:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
@@ -2716,8 +2719,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.1.28"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2732,8 +2735,8 @@ qs@~6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 randomatic@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
   dependencies:
     is-number "^4.0.0"
     kind-of "^6.0.0"
@@ -2924,7 +2927,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -3051,8 +3054,8 @@ source-map-support@^0.4.15:
     source-map "^0.5.6"
 
 source-map-support@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.7.tgz#71503b94aefbc89789841100c18c0cc63a7e6137"
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -3240,8 +3243,8 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 tar@^4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
   dependencies:
     chownr "^1.0.1"
     fs-minipass "^1.2.5"
@@ -3391,8 +3394,8 @@ uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,6 +1981,12 @@ kafkajs@^1.3.0:
   dependencies:
     long "^4.0.0"
 
+"kafkajs@https://github.com/tulios/kafkajs.git#0f04b0b080e5aaf065eca433c62a5f9c0a3efe66":
+  version "1.3.0"
+  resolved "https://github.com/tulios/kafkajs.git#0f04b0b080e5aaf065eca433c62a5f9c0a3efe66"
+  dependencies:
+    long "^4.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
This is in no way ready for a release, but it shows the general interface I'm thinking of to allow you to configure each source topic's failure behavior independently. At the moment, only the dead letter queue behavior is enabled.

Basically it would look something like this:

```javascript
const { Kafka } = require('kafkajs')
const { DLQ, failureAdapters } = require('kafkajs-dlq')

const client = new Kafka({ ... })
const dlq = new DLQ({ client })

const topic = 'example-topic'
const failureAdapter = new failureAdapters.Kafka({ client, topic: `${topic}.dead-letter` })

const { eachMessage } = dlq.consumer({
  topics: {
    [topic]: {
      delayedExecution: [ // This part is only fantasy at the moment
        { topic: `${topic}.5m`, delay: 5 * 60 * 1000 },
        { topic: `${topic}.15m`, delay: 15 * 60 * 1000 }
      ],
      failureAdapter
    }
  },
  eachMessage: async ({ topic, partition, message }) => {
    throw new Error('Failed to process message')
  }
})

const consumer = client.consumer({ ... })

const run = async () => {
  await consumer.connect()
  await consumer.subscribe({ topic })
  await consumer.run({ eachMessage })
}

run()
```

Failure adapters can be created in userland, as long as they inherit from the `FailureAdapter` class. The `Kafka` one is provided as an example.